### PR TITLE
Add fold all posts mode for easier navigation

### DIFF
--- a/src/content.css
+++ b/src/content.css
@@ -44,6 +44,12 @@
   --lpf-state-rejected-border: var(--lpf-color-success);
   --lpf-state-rejected-label-bg: var(--lpf-color-success);
   --lpf-state-rejected-label-text: #0a1a10;
+
+  /* State: Passed (for unfiltered posts in fold mode) */
+  --lpf-state-passed-bg: linear-gradient(135deg, #1a2d1a 0%, #101a10 100%);
+  --lpf-state-passed-border: var(--lpf-color-success);
+  --lpf-state-passed-label-bg: var(--lpf-color-success);
+  --lpf-state-passed-label-text: #0a1a10;
 }
 
 /* ─── Utility Classes ──────────────────────────────────────────── */
@@ -79,6 +85,52 @@
 
 .lpf-filtered--revealed .lpf-badge {
   opacity: 0.6;
+}
+
+/* ─── Fold Mode (all posts collapsed) ─────────────────────────── */
+
+.lpf-folded > *:not(.lpf-badge) {
+  display: none;
+}
+
+.lpf-folded {
+  position: relative;
+}
+
+.lpf-folded--revealed > *:not(.lpf-badge) {
+  display: revert;
+}
+
+.lpf-folded--revealed {
+  opacity: 0.7;
+}
+
+.lpf-folded--revealed .lpf-badge {
+  opacity: 0.6;
+}
+
+/* Passed badge (unfiltered posts in fold mode) */
+.lpf-badge--passed {
+  background: var(--lpf-state-passed-bg);
+  border-bottom-color: var(--lpf-state-passed-border);
+}
+
+.lpf-badge--passed .lpf-badge__icon {
+  color: var(--lpf-state-passed-border);
+}
+
+.lpf-badge--passed .lpf-badge__label {
+  background: var(--lpf-state-passed-label-bg);
+  color: var(--lpf-state-passed-label-text);
+}
+
+.lpf-badge--passed .lpf-badge__author {
+  color: var(--lpf-text-secondary);
+  font-weight: 400;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* ─── Filter Badge ─────────────────────────────────────────────── */
@@ -319,6 +371,18 @@
   background: var(--lpf-color-danger);
   color: var(--lpf-text-on-color);
   border-color: var(--lpf-color-danger);
+}
+
+#lpf-panel__fold-btn.lpf-panel__fold-btn--active {
+  background: var(--lpf-color-success);
+  color: var(--lpf-state-passed-label-text);
+  border-color: var(--lpf-color-success);
+}
+
+#lpf-panel__fold-btn.lpf-panel__fold-btn--active:hover {
+  background: var(--lpf-color-danger);
+  border-color: var(--lpf-color-danger);
+  color: var(--lpf-text-on-color);
 }
 
 /* ─── Panel Stats ──────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Adds a toggle button (▤) in the review panel header that collapses all posts to show just their badges, making it easy to scan and navigate to filtered posts.

Fixes #28

## How It Works

When fold mode is active:
- **Filtered posts**: Show existing filter badge (orange pending, red confirmed, green rejected)
- **Unfiltered posts**: Show green "Passed" badge with author name and preview button

This creates a compact view where each post is just one line, allowing quick navigation through a long feed.

## UI

```
┌─────────────────────────────────────────────────────────────┐
│ ⊘  [Engagement Bait]  Agree?                     👁  ◎  ○  │  ← Filtered
├─────────────────────────────────────────────────────────────┤
│ ✓  [Passed]  John Smith                               👁   │  ← Unfiltered
├─────────────────────────────────────────────────────────────┤
│ ✓  [Passed]  Jane Doe                                 👁   │  ← Unfiltered
└─────────────────────────────────────────────────────────────┘
```

## Manual Test Checklist

- [x] Open panel, click ▤ button → all posts collapse
- [x] Filtered posts show their category badge
- [x] Unfiltered posts show green "Passed" badge with author
- [x] Click 👁 on any post → content revealed
- [x] Click ▤ again → all posts unfold, passed badges removed
- [x] Scroll while folded → new posts also fold automatically
- [x] Rescan → fold mode persists, badges refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)