### PR TITLE
Fix preview button on filtered posts when fold mode is active

### DIFF
--- a/src/content.css
+++ b/src/content.css
@@ -89,6 +89,11 @@
 
 /* ─── Fold Mode (all posts collapsed) ─────────────────────────── */
 
+/* When a filtered post is also folded, the filtered-revealed state should win */
+.lpf-folded.lpf-filtered--revealed > *:not(.lpf-badge) {
+  display: revert;
+}
+
 .lpf-folded > *:not(.lpf-badge) {
   display: none;
 }


### PR DESCRIPTION
## Summary

- Fixes CSS cascade issue where filtered posts couldn't be previewed when fold mode was enabled
- Added higher-specificity rule to ensure `lpf-filtered--revealed` takes precedence over `lpf-folded`

Fixes #45

## Root Cause

When a post has both `lpf-filtered` and `lpf-folded` classes:
- Preview button toggles `lpf-filtered--revealed`
- But `.lpf-folded > *:not(.lpf-badge) { display: none }` came later in CSS and overrode it

## Test plan

- [x] Enable extension, let some posts get filtered
- [x] Enable fold mode (▤ button in panel)
- [x] Click preview (👁) on a **filtered** post badge
- [x] Verify the post content is revealed
- [x] Click preview again to hide
- [x] Verify preview still works on **passed** posts when folded

🤖 Generated with [Claude Code](https://claude.com/claude-code)