### PR TITLE
Fix popup API key warning showing in local mode

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -10,8 +10,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     chrome.runtime.sendMessage({ type: 'checkApiKey' }),
   ]);
 
-  // API key warning
-  if (!apiStatus.configured) {
+  // API key warning (only relevant in LLM mode)
+  if (!apiStatus.configured && settings.filterMode === 'llm') {
     apiWarning.hidden = false;
   }
 


### PR DESCRIPTION
## Summary

- Gate the popup's "No API key configured" warning on `filterMode === 'llm'`, so it no longer appears when users are running in local mode (the default)
- Aligns popup behavior with `content.js`, which already checks the filter mode correctly

Fixes #47

## Test plan

- [x] Install extension with default settings (local mode), no API key — popup should **not** show the API key warning
- [x] Switch to LLM mode without an API key — popup should show the warning
- [x] Configure an API key in LLM mode — popup should hide the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)