### PR TITLE
Add delete button for API key in options

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -35,7 +35,7 @@
         <div class="field">
           <input type="password" id="api-key" placeholder="sk-ant-..." />
           <button id="save-key-btn">Save</button>
-          <button id="delete-key-btn" class="danger">Delete</button>
+          <button id="delete-key-btn" class="danger" hidden>Delete</button>
         </div>
         <p id="key-status" class="hint"></p>
       </section>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -35,6 +35,7 @@
         <div class="field">
           <input type="password" id="api-key" placeholder="sk-ant-..." />
           <button id="save-key-btn">Save</button>
+          <button id="delete-key-btn" class="danger">Delete</button>
         </div>
         <p id="key-status" class="hint"></p>
       </section>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -41,8 +41,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   // ─── API Key ──────────────────────────────────────────────────
   const apiKeyInput = document.getElementById('api-key');
   const keyStatus = document.getElementById('key-status');
+  const deleteKeyButton = document.getElementById('delete-key-btn');
   const { configured } = await chrome.runtime.sendMessage({ type: 'checkApiKey' });
   keyStatus.textContent = configured ? 'API key is configured.' : 'No API key set.';
+  deleteKeyButton.hidden = !configured;
 
   document.getElementById('save-key-btn').addEventListener('click', async () => {
     const key = apiKeyInput.value.trim();
@@ -53,8 +55,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     deleteKeyButton.hidden = false;
   });
 
-  const deleteKeyButton = document.getElementById('delete-key-btn');
-  deleteKeyButton.hidden = !configured;
   deleteKeyButton.addEventListener('click', async () => {
     await chrome.storage.local.remove('apiKey');
     keyStatus.textContent = 'API key deleted.';

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -50,6 +50,16 @@ document.addEventListener('DOMContentLoaded', async () => {
     await chrome.storage.local.set({ apiKey: key });
     keyStatus.textContent = 'API key saved.';
     apiKeyInput.value = '';
+    deleteKeyButton.hidden = false;
+  });
+
+  const deleteKeyButton = document.getElementById('delete-key-btn');
+  deleteKeyButton.hidden = !configured;
+  deleteKeyButton.addEventListener('click', async () => {
+    await chrome.storage.local.remove('apiKey');
+    keyStatus.textContent = 'API key deleted.';
+    apiKeyInput.value = '';
+    deleteKeyButton.hidden = true;
   });
 
   // ─── Model ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add a **Delete** button next to Save in the API Key section of the options page
- Button is only visible when a key is currently configured; hides after deletion, reappears on save
- Removes the key from `chrome.storage.local` and updates the status text

Fixes #49

## Test plan

- [x] With an API key configured, open options — Delete button should be visible
- [x] Click Delete — key is removed, status shows "API key deleted.", button disappears
- [x] Save a new key — Delete button reappears
- [x] With no API key configured, open options — Delete button should be hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)